### PR TITLE
Update i18n to v0.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     factory-helper (1.5.1)
-      i18n (= 0.6.9)
+      i18n (~> 0.7)
 
 GEM
   remote: http://rubygems.org/
@@ -18,7 +18,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
-    i18n (0.6.9)
+    i18n (0.7.0)
     json (1.8.2)
     mime-types (2.5)
     netrc (0.10.3)

--- a/factory-helper.gemspec
+++ b/factory-helper.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.required_ruby_version = ">= 1.9.2"
 
-  spec.add_dependency('i18n', '0.6.9')
-
   spec.files         = `git ls-files -- lib/*`.split("\n") + %w(History.txt License.txt README.md)
   spec.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   spec.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
@@ -23,5 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_runtime_dependency "i18n", "~> 0.7"
   spec.add_development_dependency "coveralls"
 end

--- a/test/test_faker_city.rb
+++ b/test/test_faker_city.rb
@@ -2,6 +2,7 @@ require File.dirname(__FILE__) + '/test_helper.rb'
 
 class TestFakerCity < Test::Unit::TestCase
   def setup
+    I18n.reload!
     xx = {
       :faker => {
         :name => {:first_name => ['alice'], :last_name => ['smith']},

--- a/test/test_faker_commerce.rb
+++ b/test/test_faker_commerce.rb
@@ -5,15 +5,15 @@ class TestFakerCommerce < Test::Unit::TestCase
   def setup
     @tester = Faker::Commerce
   end
-  
+
   def test_color
     assert @tester.color.match(/[a-z]+\.?/)
   end
-  
+
   def test_department
     assert @tester.department.match(/[A-Z][a-z]+\.?/)
   end
-  
+
   def test_single_department_should_not_contain_separators
     assert_match(/\A[A-Za-z]+\z/, @tester.department(1))
   end
@@ -32,6 +32,7 @@ class TestFakerCommerce < Test::Unit::TestCase
       }
     }
 
+    I18n.reload!
     I18n.backend.store_translations(:xy, data)
     I18n.with_locale(:xy) do
       assert_match ' + ', @tester.department(2, true)

--- a/test/test_faker_street.rb
+++ b/test/test_faker_street.rb
@@ -2,6 +2,7 @@ require File.dirname(__FILE__) + '/test_helper.rb'
 
 class TestFakerStreet < Test::Unit::TestCase
   def setup
+    I18n.reload!
     shire = {
       :faker => {
         :address => {

--- a/test/test_flexible.rb
+++ b/test/test_flexible.rb
@@ -9,6 +9,7 @@ end
 class TestFlexible < Test::Unit::TestCase
 
   def setup
+    I18n.reload!
     I18n.backend.store_translations(:xx, :faker => {:chow => {:yummie => [:fudge, :chocolate, :caramel], :taste => "delicious"}})
     I18n.backend.store_translations(:home, :faker => {:address => {:birthplace => [:bed, :hospital, :airplane]}})
     I18n.backend.store_translations(:kindergarden, :faker => {:name => {:girls_name => [:alice, :cheryl, :tatiana]}})
@@ -35,7 +36,7 @@ class TestFlexible < Test::Unit::TestCase
       end
     end
   end
-  
+
   def test_address_is_flexible
     I18n.with_locale(:home) do
       assert [:bed, :hospital, :airplane].include? Faker::Address.birthplace


### PR DESCRIPTION
i18n dependency updated to v0.7

The changed implementation of `enforce_available_locales!` from v0.6.9 to v0.7.0 broke tests:
- originally, a locale had to be included in `I18n.available_locales` to be valid
- new implementation instead checks against `I18n.config.available_locales_set`, which is cached after first call
- adding a new locale via `I18n.backend.store_translations` raised an `InvalidLocale` error because the new locale would not be present in the cached set
- to circumvent, call `I18n.reload!` each time before `I18n.backend.store_translations`
- test suite takes twice as long to run (4.21s instead of 2.06s on my machine) :disappointed: 
