### PR TITLE
010 Correct state_abbr in en-CA.yml

### DIFF
--- a/lib/locales/en-CA.yml
+++ b/lib/locales/en-CA.yml
@@ -3,7 +3,7 @@ en-CA:
     address:
       postcode: /[A-VX-Y][0-9][A-CEJ-NPR-TV-Z] ?[0-9][A-CEJ-NPR-TV-Z][0-9]/
       state: [Alberta, British Columbia, Manitoba, New Brunswick, Newfoundland and Labrador, Nova Scotia, Northwest Territories, Nunavut, Ontario, Prince Edward Island, Quebec, Saskatchewan, Yukon]
-      state_abbr: ["AB", "BC", "MB", "NB", "NL", "NS", "NU", "NT", "ON", "PE", "QC", "SK", "YK"]
+      state_abbr: ["AB", "BC", "MB", "NB", "NL", "NS", "NU", "NT", "ON", "PE", "QC", "SK", "YT"]
       default_country: [Canada]
 
     internet:


### PR DESCRIPTION
Yukon's abbreviation is 'YT' not 'YK'
