### PR TITLE
Fix randomly failing date tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,8 +55,8 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.7)
-  coveralls
+  coveralls (~> 0.8)
   factory-helper!
-  pry
+  pry (~> 0.10)
   rake
   test-unit

--- a/factory-helper.gemspec
+++ b/factory-helper.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "pry"
+  spec.add_development_dependency "pry", "~> 0.10"
+  spec.add_development_dependency "coveralls", "~> 0.8"
   spec.add_runtime_dependency "i18n", "~> 0.7"
-  spec.add_development_dependency "coveralls"
 end

--- a/lib/factory-helper/date.rb
+++ b/lib/factory-helper/date.rb
@@ -1,6 +1,8 @@
 module FactoryHelper
   class Date < Base
+
     class << self
+
       def between(from, to)
         from = get_date_object(from)
         to   = get_date_object(to)
@@ -24,8 +26,8 @@ module FactoryHelper
 
       def birthday(min_age = 18, max_age = 65)
         t = ::Date.today
-        from =  ::Date.new(t.year - min_age, t.month, t.day)
-        to   =  ::Date.new(t.year - max_age, t.month, t.day)
+        from =  ::Date.new(t.year - min_age, t.month, t.day - 1)
+        to   =  ::Date.new(t.year - max_age, t.month, t.day + 1)
 
         between(from, to).to_date
       end

--- a/test/test_factory_helper_date.rb
+++ b/test/test_factory_helper_date.rb
@@ -62,6 +62,7 @@ class TestFactoryHelperDate < Test::Unit::TestCase
       assert birthday < date_min, "Expect > \"#{date_max}\", but got #{birthday}"
     end
   end
+
   def test_default_birthday
     min = 10
     max = 65


### PR DESCRIPTION
Ensure generated date is _between_ min & max values by adding/subtracting one day to/from boundary dates. test_factory_helper_date.rb#test_birthday exercised 1,000,000 times without failures, locally and by Travis (in 4 Ruby environments).

_If this solution works, then Test::Unit was reporting the failed results incorrectly at least in some cases._
