### PR TITLE
Canadian Postcodes also can not start with DFIOQ or U

### DIFF
--- a/lib/locales/en-CA.yml
+++ b/lib/locales/en-CA.yml
@@ -2,7 +2,7 @@
 en-CA:
   factory_helper:
     address:
-      postcode: /[A-VX-Y][0-9][A-CEJ-NPR-TV-Z] ?[0-9][A-CEJ-NPR-TV-Z][0-9]/
+      postcode: /[A-CEJ-NPR-TVXY][0-9][A-CEJ-NPR-TV-Z] ?[0-9][A-CEJ-NPR-TV-Z][0-9]/
       state: [Alberta, British Columbia, Manitoba, New Brunswick, Newfoundland and Labrador, Nova Scotia, Northwest Territories, Nunavut, Ontario, Prince Edward Island, Quebec, Saskatchewan, Yukon]
       state_abbr: ["AB", "BC", "MB", "NB", "NL", "NS", "NU", "NT", "ON", "PE", "QC", "SK", "YT"]
       default_country: [Canada]


### PR DESCRIPTION
Postal codes do not include the letters D, F, I, O, Q or U, and the
first position also does not make use of the letters W or Z
