### PR TITLE
domain_word returns incorrect value while locale is set to 'ru'

### DIFF
--- a/lib/factory-helper/internet.rb
+++ b/lib/factory-helper/internet.rb
@@ -68,7 +68,10 @@ module FactoryHelper
       end
 
       def domain_word
-        Company.name.split(' ').first.gsub(/\W/, '').downcase
+        FactoryHelper::Config.locale = nil
+        I18n.with_locale('en') do
+          return Company.name.split(' ').first.gsub(/\W/, '').downcase
+        end
       end
 
       def domain_suffix

--- a/lib/factory-helper/internet.rb
+++ b/lib/factory-helper/internet.rb
@@ -3,7 +3,7 @@ module FactoryHelper
   class Internet < Base
     class << self
       def email(name = nil)
-        [ user_name(name), domain_name ].join('@')
+        [ email_word, domain_name ].join('@')
       end
 
       def free_email(name = nil)
@@ -67,13 +67,6 @@ module FactoryHelper
         [ fix_umlauts(domain_word), domain_suffix ].join('.')
       end
 
-      def domain_word
-        FactoryHelper::Config.locale = nil
-        I18n.with_locale('en') do
-          return Company.name.split(' ').first.gsub(/\W/, '').downcase
-        end
-      end
-
       def domain_suffix
         fetch('internet.domain_suffix')
       end
@@ -124,6 +117,19 @@ module FactoryHelper
         string
       end
 
+      def domain_word
+        Lorem.word
+      end
+
+    private
+
+      def email_word
+        name= Name.first_name.downcase
+        return name unless name.empty?
+        I18n.with_locale('en') do
+          return Name.first_name.downcase
+        end
+      end
     end
   end
 end

--- a/test/test_factory_helper_internet.rb
+++ b/test/test_factory_helper_internet.rb
@@ -11,6 +11,12 @@ class TestFactoryHelperInternet < Test::Unit::TestCase
     assert @tester.email.match(/.+@.+\.\w+/)
   end
 
+  def test_email_ru
+    I18n.with_locale('ru') do
+      assert FactoryHelper::Internet.email.match(/.+@.+\.\w+/)
+    end
+  end
+
   def test_free_email
     assert @tester.free_email.match(/.+@(gmail|hotmail|yahoo)\.com/)
   end

--- a/test/test_factory_helper_internet.rb
+++ b/test/test_factory_helper_internet.rb
@@ -11,9 +11,12 @@ class TestFactoryHelperInternet < Test::Unit::TestCase
     assert @tester.email.match(/.+@.+\.\w+/)
   end
 
-  def test_email_ru
-    I18n.with_locale('ru') do
-      assert FactoryHelper::Internet.email.match(/.+@.+\.\w+/)
+  def test_localized_email
+    I18n.available_locales.each do |locale|
+      I18n.with_locale(locale) do
+        email= @tester.email
+        raise "#{locale} localized email: #{email}" unless email.match(/.+@.+\.\w+/)
+      end
     end
   end
 


### PR DESCRIPTION
Faker::Internet.email generates email without domain name https://github.com/stympy/faker/issues/247
