### PR TITLE
add entropy source

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,23 +33,20 @@ FactoryHelper::Internet.email #=> "kirsten.greenholt@corkeryfisher.info"
 
 ###Seeding
 ----------
-FactoryHelper now supports seeding of Ruby's pseudo-random number generator
+FactoryHelper now supports seeding of its pseudo-random number generator
 (PRNG) to provide deterministic output of repeated method calls.
 
 ```ruby
-FactoryHelper::Config.seed = 99
-FactoryHelper::Company.bs #=> "utilize real-time functionalities"
-FactoryHelper::Company.bs #=> "orchestrate wireless web-readiness"
+FactoryHelper::Config.seed = 42
+FactoryHelper::Company.bs #=> "seize collaborative mindshare"
+FactoryHelper::Company.bs #=> "engage strategic platforms"
+FactoryHelper::Config.seed = 42
+FactoryHelper::Company.bs #=> "seize collaborative mindshare"
+FactoryHelper::Company.bs #=> "engage strategic platforms"
 
-FactoryHelper::Config.seed = 99
-FactoryHelper::Company.bs #=> "utilize real-time functionalities"
-FactoryHelper::Company.bs #=> "orchestrate wireless web-readiness"
-
-FactoryHelper::Config.seed = nil # seeds the PRNG with Ruby's default entropy source
-
-FactoryHelper::Config.random.seed #=> 57010835277627224902731113142647237214
-
-FactoryHelper::Company.bs #=> "revolutionize plug-and-play architectures"
+FactoryHelper::Config.seed = nil # seeds the PRNG
+FactoryHelper::Config.seed #=> 6263681755117030645311740483944653976248826274740079170131
+FactoryHelper::Company.bs #=> "cultivate viral synergies"
 ```
 
 ###FactoryHelper::String

--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ FactoryHelper now supports seeding of its pseudo-random number generator
 (PRNG) to provide deterministic output of repeated method calls.
 
 ```ruby
-FactoryHelper::Config.seed = 42
+FactoryHelper::Config.set_seed 42
 FactoryHelper::Company.bs #=> "seize collaborative mindshare"
 FactoryHelper::Company.bs #=> "engage strategic platforms"
-FactoryHelper::Config.seed = 42
+FactoryHelper::Config.set_seed 42
 FactoryHelper::Company.bs #=> "seize collaborative mindshare"
 FactoryHelper::Company.bs #=> "engage strategic platforms"
 
-FactoryHelper::Config.seed = nil # seeds the PRNG
+FactoryHelper::Config.set_seed nil # seeds the PRNG
 FactoryHelper::Config.seed #=> 6263681755117030645311740483944653976248826274740079170131
 FactoryHelper::Company.bs #=> "cultivate viral synergies"
 ```

--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ FactoryHelper now supports seeding of its pseudo-random number generator
 (PRNG) to provide deterministic output of repeated method calls.
 
 ```ruby
-FactoryHelper::Config.set_seed 42
+FactoryHelper::Config.seed= 42 #=> 42
 FactoryHelper::Company.bs #=> "seize collaborative mindshare"
 FactoryHelper::Company.bs #=> "engage strategic platforms"
-FactoryHelper::Config.set_seed 42
+FactoryHelper::Config.seed= 42 #=> 42
 FactoryHelper::Company.bs #=> "seize collaborative mindshare"
 FactoryHelper::Company.bs #=> "engage strategic platforms"
 
-FactoryHelper::Config.set_seed nil # seeds the PRNG
+FactoryHelper::Config.seed= nil # seeds the PRNG using default entropy sources
 FactoryHelper::Config.seed #=> 6263681755117030645311740483944653976248826274740079170131
 FactoryHelper::Company.bs #=> "cultivate viral synergies"
 ```

--- a/lib/factory-helper.rb
+++ b/lib/factory-helper.rb
@@ -29,18 +29,14 @@ module FactoryHelper
         @random.seed
       end
 
-      def set_seed (seed)
-        if seed
-          @random= Random.new(seed)
-        else
-          @random= Random.new(Random.new_seed.to_i* Kernel.rand(18446744073709551615).to_i)
-        end
-        return self.seed
+      def seed= new_seed
+        new_seed||= Random.new_seed.to_i* Kernel.rand(18446744073709551615).to_i
+        @random= Random.new(new_seed)
       end
     end
 
     self.locale= nil
-    self.set_seed nil
+    self.seed= nil
   end
 
   class Base

--- a/lib/factory-helper.rb
+++ b/lib/factory-helper.rb
@@ -17,9 +17,6 @@ I18n.load_path += Dir[File.join(mydir, 'locales', '*.yml')]
 
 module FactoryHelper
   class Config
-    @locale = nil
-    @random = Random.new
-
     class << self
       attr_writer :locale
       attr_reader :random
@@ -28,10 +25,22 @@ module FactoryHelper
         @locale || I18n.locale
       end
 
-      def seed=(seed)
-        @random = seed ? Random.new(seed) : Random.new
+      def seed
+        @random.seed
+      end
+
+      def seed= (seed)
+        if seed
+          @random= Random.new(seed)
+        else
+          @random= Random.new(Random.new_seed.to_i* Kernel.rand(18446744073709551615).to_i)
+        end
+        return self.seed
       end
     end
+
+    self.locale= nil
+    self.seed= nil
   end
 
   class Base

--- a/lib/factory-helper.rb
+++ b/lib/factory-helper.rb
@@ -29,7 +29,7 @@ module FactoryHelper
         @random.seed
       end
 
-      def seed= (seed)
+      def set_seed (seed)
         if seed
           @random= Random.new(seed)
         else
@@ -40,7 +40,7 @@ module FactoryHelper
     end
 
     self.locale= nil
-    self.seed= nil
+    self.set_seed nil
   end
 
   class Base

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe FactoryHelper::Config do
   describe 'PRNG' do
     specify '.seed= returns new seed' do
-      expect(FactoryHelper::Config.seed= nil).to eq FactoryHelper::Config.seed
+      expect(FactoryHelper::Config.set_seed nil).to eq FactoryHelper::Config.seed
     end
 
     specify '.random.seed' do
@@ -10,13 +10,13 @@ RSpec.describe FactoryHelper::Config do
 
     specify 'use Random for entropy' do
       expect(Random).to receive(:new_seed)
-      FactoryHelper::Config.seed= nil
+      FactoryHelper::Config.set_seed nil
     end
 
     #use two entropy sources because "Starting with Unicorn 3.6.1, we have builtin workarounds for Kernel#rand and OpenSSL::Random users, but applications may use other PRNGs."
     specify 'use Kernel.rand for entropy' do
       expect(Kernel).to receive(:rand)
-      FactoryHelper::Config.seed= nil
+      FactoryHelper::Config.set_seed nil
     end
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe FactoryHelper::Config do
   describe 'PRNG' do
-    specify '.seed= returns new seed' do
+    specify '.set_seed returns new seed' do
       expect(FactoryHelper::Config.set_seed nil).to eq FactoryHelper::Config.seed
     end
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe FactoryHelper::Config do
   describe 'PRNG' do
-    specify '.set_seed returns new seed' do
-      expect(FactoryHelper::Config.set_seed nil).to eq FactoryHelper::Config.seed
+    specify '.seed= returns new seed' do
+      expect(FactoryHelper::Config.seed= nil).to eq FactoryHelper::Config.seed
     end
 
     specify '.random.seed' do
@@ -10,13 +10,13 @@ RSpec.describe FactoryHelper::Config do
 
     specify 'use Random for entropy' do
       expect(Random).to receive(:new_seed)
-      FactoryHelper::Config.set_seed nil
+      FactoryHelper::Config.seed= nil
     end
 
     #use two entropy sources because "Starting with Unicorn 3.6.1, we have builtin workarounds for Kernel#rand and OpenSSL::Random users, but applications may use other PRNGs."
     specify 'use Kernel.rand for entropy' do
       expect(Kernel).to receive(:rand)
-      FactoryHelper::Config.set_seed nil
+      FactoryHelper::Config.seed= nil
     end
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe FactoryHelper::Config do
+  describe 'PRNG' do
+    specify '.seed= returns new seed' do
+      expect(FactoryHelper::Config.seed= nil).to eq FactoryHelper::Config.seed
+    end
+
+    specify '.random.seed' do
+      expect(FactoryHelper::Config.random.seed).to eq FactoryHelper::Config.seed
+    end
+
+    specify 'use Random for entropy' do
+      expect(Random).to receive(:new_seed)
+      FactoryHelper::Config.seed= nil
+    end
+
+    #use two entropy sources because "Starting with Unicorn 3.6.1, we have builtin workarounds for Kernel#rand and OpenSSL::Random users, but applications may use other PRNGs."
+    specify 'use Kernel.rand for entropy' do
+      expect(Kernel).to receive(:rand)
+      FactoryHelper::Config.seed= nil
+    end
+  end
+end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,9 +1,5 @@
 RSpec.describe FactoryHelper::Config do
   describe 'PRNG' do
-    specify '.seed= returns new seed' do
-      expect(FactoryHelper::Config.seed= nil).to eq FactoryHelper::Config.seed
-    end
-
     specify '.random.seed' do
       expect(FactoryHelper::Config.random.seed).to eq FactoryHelper::Config.seed
     end

--- a/test/test_determinism.rb
+++ b/test/test_determinism.rb
@@ -8,12 +8,12 @@ class TestDeterminism < Test::Unit::TestCase
   end
 
   def test_determinism
-    FactoryHelper::Config.set_seed 42
+    FactoryHelper::Config.seed= 42
     @all_methods.each_index do |index|
       store_result @all_methods[index]
     end
     @first_run.freeze
-    FactoryHelper::Config.set_seed 42
+    FactoryHelper::Config.seed= 42
     @all_methods.each_index do |index|
       assert deterministic_random? @first_run[index], @all_methods[index]
     end

--- a/test/test_determinism.rb
+++ b/test/test_determinism.rb
@@ -8,12 +8,12 @@ class TestDeterminism < Test::Unit::TestCase
   end
 
   def test_determinism
-    FactoryHelper::Config.seed= 42
+    FactoryHelper::Config.set_seed 42
     @all_methods.each_index do |index|
       store_result @all_methods[index]
     end
     @first_run.freeze
-    FactoryHelper::Config.seed= 42
+    FactoryHelper::Config.set_seed 42
     @all_methods.each_index do |index|
       assert deterministic_random? @first_run[index], @all_methods[index]
     end


### PR DESCRIPTION
When preload_app is turned on in Unicorn, each worker seems to spawn with the same seed.  So, if you had 7 workers, you'd have seven random seeds total and each call to FH would return one of seven results.  Adds another entropy source.
