### PR TITLE
Update i18n

### DIFF
--- a/factory-helper.gemspec
+++ b/factory-helper.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0.10"
   spec.add_development_dependency "coveralls", "~> 0.8"
   spec.add_development_dependency "rspec", "~> 3.2"
-  spec.add_runtime_dependency "i18n", "~> 0.7"
+  spec.add_runtime_dependency "i18n", "~> 1.0"
 end


### PR DESCRIPTION
Update the i18n version to ~> 1.0 to allow any 1.x version. 

We are using factory-helper 1.8.0 and trying to upgrade to the latest i18n version, but factory-helper 1.8.0 has locked it to ~> 0.7.